### PR TITLE
feat: align calendar typography tokens

### DIFF
--- a/ios/translation/DesignSystem/DesignSystem.swift
+++ b/ios/translation/DesignSystem/DesignSystem.swift
@@ -234,9 +234,13 @@ enum DS {
         // Serif = Songti
         static let serifTitle = customOrSystemCandidates(FontFamily.songtiCandidates, size: 22, relativeTo: .title2)
         static let serifBody = customOrSystemCandidates(FontFamily.songtiCandidates, size: 17, relativeTo: .body)
+        static let serifDisplay = customOrSystemCandidates(FontFamily.songtiCandidates, size: 28, relativeTo: .title)
+        static let serifHero = customOrSystemCandidates(FontFamily.songtiCandidates, size: 52, relativeTo: .largeTitle)
 
         static let scriptDisplay = customOrSystemCandidates(FontFamily.tangerineCandidates, size: 34, relativeTo: .largeTitle)
         static let scriptTitle = customOrSystemCandidates(FontFamily.tangerineCandidates, size: 24, relativeTo: .title2)
+        static let scriptHero = customOrSystemCandidates(FontFamily.tangerineCandidates, size: 60, relativeTo: .largeTitle)
+        static let scriptLarge = customOrSystemCandidates(FontFamily.tangerineCandidates, size: 40, relativeTo: .title)
 
         // Monospace-like usage still use Avenir per requirement
         static let mono = customOrSystemCandidates(FontFamily.avenirCandidates, size: 15, relativeTo: .callout)

--- a/ios/translation/Features/Calendar/Views/DayDetailView.swift
+++ b/ios/translation/Features/Calendar/Views/DayDetailView.swift
@@ -24,25 +24,14 @@ struct DayDetailView: View {
         HStack(alignment: .center, spacing: DS.Spacing.lg) {
             HStack(alignment: .bottom, spacing: DS.Spacing.xs2) {
                 Text(formattedMonth)
-                    .font(.custom(
-                        DS.FontFamily.tangerineCandidates.first ?? "Tangerine-Bold",
-                        size: 60
-                    ))
-                    .kerning(1.4)
+                    .dsType(DS.Font.scriptHero, lineSpacing: 0, tracking: 1.4)
 
                 Text("/")
-                    .font(.custom(
-                        DS.FontFamily.tangerineCandidates.first ?? "Tangerine-Regular",
-                        size: 42
-                    ))
+                    .dsType(DS.Font.scriptLarge, lineSpacing: 0)
                     .baselineOffset(8)
 
                 Text(formattedDay)
-                    .font(.custom(
-                        DS.FontFamily.tangerineCandidates.first ?? "Tangerine-Regular",
-                        size: 40
-                    ))
-                    .kerning(1.0)
+                    .dsType(DS.Font.scriptLarge, lineSpacing: 0, tracking: 1.0)
             }
 
             Spacer(minLength: DS.Spacing.md)
@@ -74,7 +63,8 @@ struct DayDetailView: View {
     private func metricColumn(label: LocalizedStringKey, value: String) -> some View {
         VStack(spacing: DS.Spacing.xs) {
             Text(value)
-                .font(.system(size: 28, weight: .semibold, design: .serif))
+                .dsType(DS.Font.serifDisplay, lineSpacing: 0)
+                .fontWeight(.semibold)
                 .foregroundStyle(DS.Palette.primary)
 
             Text(label)
@@ -224,7 +214,8 @@ private struct AnimatedStreakBadge: View {
     private var badgeContent: some View {
         GeometryReader { geo in
             Text("\(streakDays)")
-                .font(.system(size: geo.size.width * 0.62, weight: .semibold, design: .serif))
+                .dsType(DS.Font.serifHero, lineSpacing: 0)
+                .fontWeight(.semibold)
                 .foregroundStyle(textGradient)
                 .shadow(color: Color.white.opacity(0.18), radius: 4, y: 1)
                 .frame(width: geo.size.width, height: geo.size.height)


### PR DESCRIPTION
## Summary
- add large serif and script typography tokens for calendar displays
- apply design system fonts to the calendar day detail view with dsType spacing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0dc93d8088331acad42566a209454