### PR TITLE
refactor: align design tokens with spacing spec

### DIFF
--- a/ios/translation/DesignSystem/BannerCenter.swift
+++ b/ios/translation/DesignSystem/BannerCenter.swift
@@ -42,7 +42,7 @@ struct BannerHost: View {
                 }
                 .padding(.horizontal, DS.Spacing.md2)
                 .padding(.vertical, DS.Spacing.sm)
-                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: DS.Radius.md2, style: .continuous))
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: DS.Radius.lg, style: .continuous))
                 .shadow(color: .black.opacity(0.15), radius: 12, x: 0, y: 6)
                 // keep it off the edges (bottom-right corner)
                 .padding(.trailing, DS.Spacing.lg)

--- a/ios/translation/DesignSystem/Components/DSButtonStyles.swift
+++ b/ios/translation/DesignSystem/Components/DSButtonStyles.swift
@@ -61,7 +61,7 @@ struct DSButton: ButtonStyle {
         case .primary:
             shape.fill(DS.Palette.primaryGradient)
         case .secondary:
-            shape.stroke(DS.Palette.primary.opacity(DS.Opacity.border), lineWidth: DS.BorderWidth.regular)
+            shape.stroke(DS.Palette.primary.opacity(DS.Opacity.border), lineWidth: DS.BorderWidth.thin)
         }
     }
 }
@@ -87,7 +87,7 @@ struct DSCardLinkStyle: ButtonStyle {
             .scaleEffect(configuration.isPressed ? 0.98 : 1)
             .overlay(
                 RoundedRectangle(cornerRadius: DS.Radius.lg, style: .continuous)
-                    .stroke(DS.Palette.primary.opacity(configuration.isPressed ? DS.Opacity.strong : 0), lineWidth: DS.BorderWidth.regular)
+                    .stroke(DS.Palette.primary.opacity(configuration.isPressed ? DS.Opacity.strong : 0), lineWidth: DS.BorderWidth.thin)
             )
             .dsAnimation(DS.AnimationToken.snappy, value: configuration.isPressed)
     }

--- a/ios/translation/DesignSystem/Components/DSFilterChipsView.swift
+++ b/ios/translation/DesignSystem/Components/DSFilterChipsView.swift
@@ -47,8 +47,8 @@ struct DSFilterChip: View {
             )
             .overlay(
                 Capsule().stroke(
-                    selected ? color.opacity(DS.Opacity.muted) : DS.Palette.border.opacity(DS.Opacity.border),
-                    lineWidth: selected ? 1.1 : 0.8
+                    selected ? color.opacity(DS.Opacity.strong) : DS.Palette.border.opacity(DS.Opacity.border),
+                    lineWidth: selected ? DS.BorderWidth.thin : DS.BorderWidth.hairline
                 )
             )
         }
@@ -95,8 +95,8 @@ struct DSDifficultyFilterChip: View {
             )
             .overlay(
                 Capsule().stroke(
-                    selected ? difficultyColor.opacity(DS.Opacity.muted) : DS.Palette.border.opacity(DS.Opacity.border),
-                    lineWidth: selected ? 1.1 : 0.8
+                    selected ? difficultyColor.opacity(DS.Opacity.strong) : DS.Palette.border.opacity(DS.Opacity.border),
+                    lineWidth: selected ? DS.BorderWidth.thin : DS.BorderWidth.hairline
                 )
             )
         }

--- a/ios/translation/DesignSystem/Components/DSOutlineCard.swift
+++ b/ios/translation/DesignSystem/Components/DSOutlineCard.swift
@@ -20,7 +20,7 @@ struct DSOutlineCard<Content: View>: View {
         .background((fill ?? DS.Palette.background), in: RoundedRectangle(cornerRadius: DS.Radius.lg, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: DS.Radius.lg, style: .continuous)
-                .strokeBorder(DS.Palette.border.opacity(DS.Opacity.strong), lineWidth: DS.BorderWidth.regular)
+                .strokeBorder(DS.Palette.border.opacity(DS.Opacity.strong), lineWidth: DS.BorderWidth.thin)
         )
     }
 }

--- a/ios/translation/DesignSystem/Components/DSScoreBadge.swift
+++ b/ios/translation/DesignSystem/Components/DSScoreBadge.swift
@@ -19,7 +19,7 @@ struct DSScoreBadge: View {
 
         var padding: EdgeInsets {
             switch self {
-            case .default: return EdgeInsets(top: DS.Spacing.xs, leading: DS.Spacing.xs2, bottom: DS.Spacing.xs, trailing: DS.Spacing.xs2)
+            case .default: return EdgeInsets(top: DS.Spacing.xs, leading: DS.Spacing.sm, bottom: DS.Spacing.xs, trailing: DS.Spacing.sm)
             case .compact: return EdgeInsets(top: 2, leading: DS.Spacing.xs, bottom: 2, trailing: DS.Spacing.xs)
             case .large: return EdgeInsets(top: DS.Spacing.xs, leading: DS.Spacing.sm, bottom: DS.Spacing.xs, trailing: DS.Spacing.sm)
             }

--- a/ios/translation/DesignSystem/Components/DSStatItem.swift
+++ b/ios/translation/DesignSystem/Components/DSStatItem.swift
@@ -6,7 +6,7 @@ struct DSStatItem: View {
     let value: String
 
     var body: some View {
-        VStack(spacing: DS.Spacing.xs2) {
+        VStack(spacing: DS.Spacing.sm) {
             Image(systemName: icon)
                 .font(.caption)
                 .foregroundStyle(DS.Palette.primary)

--- a/ios/translation/DesignSystem/Components/DSTextArea.swift
+++ b/ios/translation/DesignSystem/Components/DSTextArea.swift
@@ -38,7 +38,7 @@ struct DSTextArea: View {
         )
         .overlay(
             RoundedRectangle(cornerRadius: DS.Radius.md, style: .continuous)
-                .stroke(isFocused ? DS.Palette.primary.opacity(DS.Opacity.strong) : DS.Palette.border.opacity(DS.Opacity.border), lineWidth: DS.BorderWidth.regular)
+                .stroke(isFocused ? DS.Palette.primary.opacity(DS.Opacity.strong) : DS.Palette.border.opacity(DS.Opacity.border), lineWidth: DS.BorderWidth.thin)
         )
         .dsAnimation(DS.AnimationToken.subtle, value: isFocused)
     }

--- a/ios/translation/DesignSystem/DesignSystem.swift
+++ b/ios/translation/DesignSystem/DesignSystem.swift
@@ -9,14 +9,14 @@ enum DS {
         static var hairline: CGFloat { max(1 / UIScreen.main.scale, 0.5) }
     }
     enum Spacing {
-        static let xs: CGFloat = 6
-        static let xs2: CGFloat = 8
-        static let sm: CGFloat = 10
-        static let sm2: CGFloat = 12
-        static let md2: CGFloat = 14
-        static let md: CGFloat = 16
-        static let lg: CGFloat = 24
-        static let xl: CGFloat = 32
+        static let xs: CGFloat = 4
+        static let sm2: CGFloat = 6
+        static let sm: CGFloat = 8
+        static let md2: CGFloat = 10
+        static let md: CGFloat = 12
+        static let lg: CGFloat = 16
+        static let xl: CGFloat = 20
+        static let xxl: CGFloat = 24
     }
 
     // Standardized border widths so we avoid magic numbers
@@ -24,19 +24,16 @@ enum DS {
         // Hairline should reflect device pixel ratio; reuse Metrics.hairline
         static var hairline: CGFloat { DS.Metrics.hairline }
         // Thin cosmetic borders (chips, badges)
-        static let thin: CGFloat = 0.8
-        // Regular 1pt borders (inputs, buttons, outlines)
-        static let regular: CGFloat = 1.0
-        // Emphasized outline for badges/pills
-        static let emphatic: CGFloat = 1.6
+        static let thin: CGFloat = 1.0
+        // Regular emphasis borders (inputs, buttons, outlines)
+        static let regular: CGFloat = 2.0
     }
 
     enum Radius {
-        static let xs: CGFloat = 6
-        static let sm: CGFloat = 8
-        static let md: CGFloat = 12
-        static let md2: CGFloat = 14
-        static let lg: CGFloat = 16
+        static let sm: CGFloat = 6
+        static let md: CGFloat = 10
+        static let lg: CGFloat = 14
+        static let xl: CGFloat = 20
     }
 
     enum Shadow {
@@ -82,12 +79,10 @@ enum DS {
 
     // Opacity tokens (avoid magic numbers sprinkled around)
     enum Opacity {
-        static let fill: Double = 0.12      // chip/card subtle fills
-        static let hairline: Double = 0.18  // hairline borders
-        static let border: Double = 0.35    // default outlines/separators
-        static let strong: Double = 0.45    // emphasized outlines/highlight
-        static let muted: Double = 0.60     // subdued foregrounds/status
-        static let accentLight: Double = 0.28 // accent separators/light tints
+        static let hairline: Double = 0.15  // hairline borders
+        static let border: Double = 0.20    // default outlines/separators
+        static let fill: Double = 0.08      // chip/card subtle fills
+        static let strong: Double = 0.40    // emphasized outlines/highlight
     }
 
     enum Component {
@@ -110,7 +105,7 @@ enum DS {
         }
 
         enum OverlayCard {
-            static let paddingHorizontal: CGFloat = 20
+            static let paddingHorizontal: CGFloat = DS.Spacing.xl
             static let paddingVertical: CGFloat = DS.Spacing.md
             static let cornerRadius: CGFloat = DS.Radius.lg
         }
@@ -421,7 +416,7 @@ struct DSQuickActionIconGlyph: View {
                 Group {
                     if let borderColor {
                         RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                            .stroke(borderColor, lineWidth: DS.BorderWidth.regular)
+                            .stroke(borderColor, lineWidth: DS.BorderWidth.thin)
                     }
                 }
             )

--- a/ios/translation/Features/Calendar/Views/DayDetailView.swift
+++ b/ios/translation/Features/Calendar/Views/DayDetailView.swift
@@ -22,7 +22,7 @@ struct DayDetailView: View {
 
     private var headerSection: some View {
         HStack(alignment: .center, spacing: DS.Spacing.lg) {
-            HStack(alignment: .bottom, spacing: DS.Spacing.xs2) {
+            HStack(alignment: .bottom, spacing: DS.Spacing.sm) {
                 Text(formattedMonth)
                     .font(.custom(
                         DS.FontFamily.tangerineCandidates.first ?? "Tangerine-Bold",
@@ -144,7 +144,7 @@ private struct AnimatedStreakBadge: View {
     ]
 
     private let badgeSize: CGFloat = 88
-    private let outerLineWidth: CGFloat = DS.BorderWidth.emphatic
+    private let outerLineWidth: CGFloat = DS.BorderWidth.regular
     private let innerLineWidth: CGFloat = DS.BorderWidth.hairline
     private let innerInset: CGFloat = 8
     private let fillInset: CGFloat = 16

--- a/ios/translation/Features/Chat/Bank/Views/AllBankItemsView.swift
+++ b/ios/translation/Features/Chat/Bank/Views/AllBankItemsView.swift
@@ -262,7 +262,7 @@ struct AllBankItemsView: View {
                             .padding(.horizontal, 12)
                             .background(
                                 RoundedRectangle(cornerRadius: DS.Radius.md, style: .continuous)
-                                    .stroke(DS.Palette.border.opacity(DS.Opacity.muted), lineWidth: DS.BorderWidth.regular)
+                                    .stroke(DS.Palette.border.opacity(DS.Opacity.strong), lineWidth: DS.BorderWidth.thin)
                                     .background(DS.Palette.surface.opacity(0.0001))
                             )
 

--- a/ios/translation/Features/Chat/Bank/Views/LocalBankListView.swift
+++ b/ios/translation/Features/Chat/Bank/Views/LocalBankListView.swift
@@ -195,7 +195,7 @@ struct LocalBankListView: View {
                             .padding(.horizontal, 12)
                             .background(
                                 RoundedRectangle(cornerRadius: DS.Radius.md, style: .continuous)
-                                    .stroke(DS.Palette.border.opacity(DS.Opacity.muted), lineWidth: DS.BorderWidth.regular)
+                                    .stroke(DS.Palette.border.opacity(DS.Opacity.strong), lineWidth: DS.BorderWidth.thin)
                                     .background(DS.Palette.surface.opacity(0.0001))
                             )
                         HStack(alignment: .center, spacing: 8) {

--- a/ios/translation/Features/Chat/Views/ChatComposerComponents.swift
+++ b/ios/translation/Features/Chat/Views/ChatComposerComponents.swift
@@ -55,7 +55,7 @@ struct AdaptiveComposer: View {
         )
         .overlay(
             RoundedRectangle(cornerRadius: DS.Radius.md, style: .continuous)
-                .stroke(isFocused ? DS.Palette.primary.opacity(DS.Opacity.strong) : DS.Palette.border.opacity(DS.Opacity.border), lineWidth: DS.BorderWidth.regular)
+                .stroke(isFocused ? DS.Palette.primary.opacity(DS.Opacity.strong) : DS.Palette.border.opacity(DS.Opacity.border), lineWidth: DS.BorderWidth.thin)
         )
         .contentShape(Rectangle())
         .onTapGesture {

--- a/ios/translation/Features/Flashcards/Components/FlashcardsViews/FlashcardsFlipCard.swift
+++ b/ios/translation/Features/Flashcards/Components/FlashcardsViews/FlashcardsFlipCard.swift
@@ -32,7 +32,7 @@ struct FlashcardsFlipCard<Front: View, Back: View, Overlay: View>: View {
         .background(DS.Palette.surface)
         .overlay(
             RoundedRectangle(cornerRadius: DS.Radius.lg, style: .continuous)
-                .stroke(DS.Palette.border, lineWidth: DS.BorderWidth.regular)
+                .stroke(DS.Palette.border, lineWidth: DS.BorderWidth.thin)
         )
         .frame(minHeight: 240)
         .frame(maxHeight: .infinity)

--- a/ios/translation/Features/Flashcards/Components/FlashcardsViews/SideCountBadge.swift
+++ b/ios/translation/Features/Flashcards/Components/FlashcardsViews/SideCountBadge.swift
@@ -13,8 +13,8 @@ struct SideCountBadge: View {
             .padding(.vertical, DS.Spacing.xs)
             .padding(.horizontal, DS.Spacing.sm)
             .background(
-                RoundedRectangle(cornerRadius: DS.Radius.xs, style: .continuous)
-                    .stroke(color, lineWidth: DS.BorderWidth.regular)
+                RoundedRectangle(cornerRadius: DS.Radius.sm, style: .continuous)
+                    .stroke(color, lineWidth: DS.BorderWidth.thin)
             )
             .opacity(filled ? 1.0 : 0.6)
             .scaleEffect(filled ? 1.1 : 1.0)

--- a/ios/translation/Features/Saved/Components/PracticeRecordCard.swift
+++ b/ios/translation/Features/Saved/Components/PracticeRecordCard.swift
@@ -113,7 +113,7 @@ struct PracticeRecordCard: View {
     }
 
     private var collapsedPreview: some View {
-        VStack(alignment: .leading, spacing: DS.Spacing.xs2) {
+        VStack(alignment: .leading, spacing: DS.Spacing.sm) {
             Text(record.chineseText)
                 .dsType(DS.Font.serifBody)
                 .lineLimit(2)
@@ -157,13 +157,13 @@ struct PracticeRecordCard: View {
             }
 
             if !record.errors.isEmpty {
-                VStack(alignment: .leading, spacing: DS.Spacing.xs2) {
+                VStack(alignment: .leading, spacing: DS.Spacing.sm) {
                     Text("practice.records.card.errors")
                         .dsType(DS.Font.caption)
                         .foregroundStyle(.tertiary)
 
                     ForEach(uniqueErrorTypes, id: \.id) { type in
-                        HStack(spacing: DS.Spacing.xs2) {
+                        HStack(spacing: DS.Spacing.sm) {
                             Circle()
                                 .fill(type.color.opacity(0.7))
                                 .frame(width: 6, height: 6)
@@ -186,7 +186,7 @@ struct PracticeRecordCard: View {
         }
         .dsType(DS.Font.caption)
         .foregroundStyle(.secondary)
-        .padding(.horizontal, DS.Spacing.xs2)
+        .padding(.horizontal, DS.Spacing.sm)
         .padding(.vertical, 4)
         .background(
             Capsule()
@@ -214,7 +214,7 @@ struct PracticeRecordCard: View {
     }
 
     private func detailSection(titleKey: LocalizedStringKey, text: String, style: DetailTextStyle) -> some View {
-        VStack(alignment: .leading, spacing: DS.Spacing.xs2) {
+        VStack(alignment: .leading, spacing: DS.Spacing.sm) {
             Text(titleKey)
                 .dsType(DS.Font.caption)
                 .foregroundStyle(.tertiary)

--- a/ios/translation/Features/Workspace/Components/ChinesePromptView.swift
+++ b/ios/translation/Features/Workspace/Components/ChinesePromptView.swift
@@ -14,7 +14,7 @@ struct ChinesePromptView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .overlay(
                         RoundedRectangle(cornerRadius: DS.Radius.md, style: .continuous)
-                            .stroke(DS.Palette.border.opacity(0.4), lineWidth: DS.BorderWidth.regular)
+                            .stroke(DS.Palette.border.opacity(0.4), lineWidth: DS.BorderWidth.thin)
                     )
             } else {
                 Text(text)
@@ -24,7 +24,7 @@ struct ChinesePromptView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .overlay(
                         RoundedRectangle(cornerRadius: DS.Radius.md, style: .continuous)
-                            .stroke(DS.Brand.scheme.babyBlue.opacity(0.45), lineWidth: DS.BorderWidth.regular)
+                            .stroke(DS.Brand.scheme.babyBlue.opacity(0.45), lineWidth: DS.BorderWidth.thin)
                     )
                     .overlay(alignment: .leading) {
                         LinearGradient(colors: [DS.Brand.scheme.cornhusk, DS.Brand.scheme.peachQuartz], startPoint: .top, endPoint: .bottom)

--- a/ios/translation/Features/Workspace/Components/ErrorItemRow.swift
+++ b/ios/translation/Features/Workspace/Components/ErrorItemRow.swift
@@ -7,8 +7,8 @@ struct ErrorItemRow: View {
 
     var body: some View {
         let theme = ErrorTheme.theme(for: err.type)
-        VStack(alignment: .leading, spacing: DS.Spacing.xs2) {
-            HStack(alignment: .firstTextBaseline, spacing: DS.Spacing.xs2) {
+        VStack(alignment: .leading, spacing: DS.Spacing.sm) {
+            HStack(alignment: .firstTextBaseline, spacing: DS.Spacing.sm) {
                 TagLabel(text: err.type.displayName, color: err.type.color)
                 Text(err.span)
                     .dsType(DS.Font.body)
@@ -19,7 +19,7 @@ struct ErrorItemRow: View {
                 .dsType(DS.Font.body, lineSpacing: 4)
                 .foregroundStyle(.secondary)
             if let s = err.suggestion, !s.isEmpty {
-                HStack(spacing: DS.Spacing.xs2) {
+                HStack(spacing: DS.Spacing.sm) {
                     Text("error.suggestion")
                         .dsType(DS.Font.caption)
                         .foregroundStyle(.secondary)

--- a/ios/translation/Features/Workspace/Components/TypeChipsView.swift
+++ b/ios/translation/Features/Workspace/Components/TypeChipsView.swift
@@ -53,7 +53,10 @@ struct TypeChipsView: View {
                     Capsule().fill(selected ? color.opacity(0.15) : DS.Palette.surface)
                 )
                 .overlay(
-                    Capsule().stroke(selected ? color.opacity(DS.Opacity.muted) : DS.Palette.border.opacity(DS.Opacity.border), lineWidth: selected ? 1.1 : 0.8)
+                    Capsule().stroke(
+                        selected ? color.opacity(DS.Opacity.strong) : DS.Palette.border.opacity(DS.Opacity.border),
+                        lineWidth: selected ? DS.BorderWidth.thin : DS.BorderWidth.hairline
+                    )
                 )
             }
             .buttonStyle(.plain)

--- a/ios/translation/Features/Workspace/Views/WorkspaceListView.swift
+++ b/ios/translation/Features/Workspace/Views/WorkspaceListView.swift
@@ -243,7 +243,7 @@ private struct WorkspaceItemLink: View {
         if vm.isLoading { return DS.Palette.primary }
         if vm.response != nil { return DS.Brand.scheme.cornhusk }
         if !(vm.inputZh.isEmpty && vm.inputEn.isEmpty) { return DS.Brand.scheme.monument }
-        return DS.Palette.border.opacity(DS.Opacity.muted)
+        return DS.Palette.border.opacity(DS.Opacity.strong)
     }
 
     var body: some View {
@@ -572,7 +572,7 @@ private struct StatusBadge: View {
     var textKey: LocalizedStringKey
     var color: Color
     var body: some View {
-        DSBadge(style: .outline(color: color.opacity(DS.Opacity.strong), lineWidth: DS.BorderWidth.emphatic)) {
+        DSBadge(style: .outline(color: color.opacity(DS.Opacity.strong), lineWidth: DS.BorderWidth.regular)) {
             HStack(spacing: 8) {
                 Circle().fill(color).frame(width: 8, height: 8)
                 Text(textKey).dsType(DS.Font.caption).foregroundStyle(.secondary)


### PR DESCRIPTION
## Summary
- update DS spacing, border, radius, and opacity tokens to match design system guidance
- replace usages of deprecated spacing/border tokens across saved, workspace, calendar, chat bank, and flashcards views
- adjust border widths and chip outlines to respect new hairline/thin/regular scale

## Testing
- not run (iOS build tooling unavailable in container environment)

------
https://chatgpt.com/codex/tasks/task_e_68d0dc9255d883319d06ec3fba416ca0