### PR TITLE
Refactor correction workflow collaborators

### DIFF
--- a/ios/translation/Features/Workspace/ViewModels/CorrectionPersistence.swift
+++ b/ios/translation/Features/Workspace/ViewModels/CorrectionPersistence.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+struct CorrectionPersistenceState {
+    var inputZh: String = ""
+    var inputEn: String = ""
+    var response: AIResponse? = nil
+    var practicedHints: [BankHint] = []
+    var showPracticedHints: Bool = false
+}
+
+protocol CorrectionPersistence {
+    func load() -> CorrectionPersistenceState
+    func saveInputZh(_ value: String)
+    func saveInputEn(_ value: String)
+    func saveResponse(_ response: AIResponse?)
+    func saveHints(_ hints: [BankHint])
+    func saveShowPracticedHints(_ value: Bool)
+    func clearAll()
+}
+
+final class UserDefaultsCorrectionPersistence: CorrectionPersistence {
+    private let defaults: UserDefaults
+    private let keyInputZh: String
+    private let keyInputEn: String
+    private let keyResponse: String
+    private let keyHints: String
+    private let keyShowHints: String
+
+    init(workspaceID: String, defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        let prefix = "workspace.\(workspaceID)."
+        self.keyInputZh = prefix + "inputZh"
+        self.keyInputEn = prefix + "inputEn"
+        self.keyResponse = prefix + "response"
+        self.keyHints = prefix + "practicedHints"
+        self.keyShowHints = prefix + "showPracticedHints"
+    }
+
+    func load() -> CorrectionPersistenceState {
+        var state = CorrectionPersistenceState()
+        state.inputZh = defaults.string(forKey: keyInputZh) ?? ""
+        state.inputEn = defaults.string(forKey: keyInputEn) ?? ""
+        if let data = defaults.data(forKey: keyResponse) {
+            state.response = try? JSONDecoder().decode(AIResponse.self, from: data)
+        }
+        if let data = defaults.data(forKey: keyHints),
+           let hints = try? JSONDecoder().decode([BankHint].self, from: data) {
+            state.practicedHints = hints
+        }
+        state.showPracticedHints = defaults.bool(forKey: keyShowHints)
+        return state
+    }
+
+    func saveInputZh(_ value: String) {
+        defaults.set(value, forKey: keyInputZh)
+    }
+
+    func saveInputEn(_ value: String) {
+        defaults.set(value, forKey: keyInputEn)
+    }
+
+    func saveResponse(_ response: AIResponse?) {
+        if let response, let data = try? JSONEncoder().encode(response) {
+            defaults.set(data, forKey: keyResponse)
+        } else {
+            defaults.removeObject(forKey: keyResponse)
+        }
+    }
+
+    func saveHints(_ hints: [BankHint]) {
+        guard !hints.isEmpty else {
+            defaults.removeObject(forKey: keyHints)
+            return
+        }
+        if let data = try? JSONEncoder().encode(hints) {
+            defaults.set(data, forKey: keyHints)
+        }
+    }
+
+    func saveShowPracticedHints(_ value: Bool) {
+        defaults.set(value, forKey: keyShowHints)
+    }
+
+    func clearAll() {
+        defaults.removeObject(forKey: keyInputZh)
+        defaults.removeObject(forKey: keyInputEn)
+        defaults.removeObject(forKey: keyResponse)
+        defaults.removeObject(forKey: keyHints)
+        defaults.removeObject(forKey: keyShowHints)
+    }
+}

--- a/ios/translation/Features/Workspace/ViewModels/CorrectionPracticeSession.swift
+++ b/ios/translation/Features/Workspace/ViewModels/CorrectionPracticeSession.swift
@@ -1,0 +1,169 @@
+import Foundation
+
+enum CorrectionPracticeSource: Equatable {
+    case local(bookName: String)
+}
+
+enum CorrectionPracticeSessionError: LocalizedError, Equatable {
+    case notLocal
+    case missingLocalStores
+    case missingPracticeStore
+    case noRemainingItems
+
+    var errorDescription: String? {
+        switch self {
+        case .notLocal:
+            return String(localized: "practice.error.notLocal")
+        case .missingLocalStores:
+            return String(localized: "practice.error.storeMissing")
+        case .missingPracticeStore:
+            return String(localized: "practice.error.practiceStoreMissing", defaultValue: "Practice records store not configured")
+        case .noRemainingItems:
+            return String(localized: "practice.error.noneRemaining")
+        }
+    }
+}
+
+struct CorrectionPracticeState {
+    var inputZh: String
+    var inputEn: String
+    var practicedHints: [BankHint]
+    var showPracticedHints: Bool
+    var response: AIResponse?
+    var practiceSource: CorrectionPracticeSource?
+    var currentBankItemId: String?
+    var currentPracticeTag: String?
+    var suggestion: String?
+}
+
+protocol CorrectionPracticeSession {
+    var practiceSource: CorrectionPracticeSource? { get }
+    var currentBankItemId: String? { get }
+    var currentPracticeTag: String? { get }
+    var currentSuggestion: String? { get }
+
+    func bindLocalStores(localBank: LocalBankStore, progress: LocalBankProgressStore)
+    func bindPracticeRecordsStore(_ store: PracticeRecordsStore)
+    func startLocalPractice(bookName: String, item: BankItem, tag: String?) -> CorrectionPracticeState
+    func loadNextPractice() async throws -> CorrectionPracticeState
+    func savePracticeRecord(response: AIResponse, inputZh: String, inputEn: String, hints: [BankHint]) throws -> PracticeRecord
+    func resetContext()
+}
+
+final class DefaultCorrectionPracticeSession: CorrectionPracticeSession {
+    private(set) var practiceSource: CorrectionPracticeSource? = nil
+    private(set) var currentBankItemId: String? = nil
+    private(set) var currentPracticeTag: String? = nil
+    private(set) var currentSuggestion: String? = nil
+
+    private weak var localBankStore: LocalBankStore?
+    private weak var localProgressStore: LocalBankProgressStore?
+    private weak var practiceRecordsStore: PracticeRecordsStore?
+
+    private var practiceStartTime: Date? = nil
+
+    func bindLocalStores(localBank: LocalBankStore, progress: LocalBankProgressStore) {
+        self.localBankStore = localBank
+        self.localProgressStore = progress
+    }
+
+    func bindPracticeRecordsStore(_ store: PracticeRecordsStore) {
+        self.practiceRecordsStore = store
+    }
+
+    func startLocalPractice(bookName: String, item: BankItem, tag: String?) -> CorrectionPracticeState {
+        updatePracticeContext(source: .local(bookName: bookName), item: item, tag: tag ?? item.tags?.first)
+        return buildState(from: item)
+    }
+
+    func loadNextPractice() async throws -> CorrectionPracticeState {
+        guard case .local(let bookName) = practiceSource else {
+            throw CorrectionPracticeSessionError.notLocal
+        }
+        guard let bank = localBankStore, let progress = localProgressStore else {
+            throw CorrectionPracticeSessionError.missingLocalStores
+        }
+
+        let items = bank.items(in: bookName)
+        guard !items.isEmpty else {
+            throw CorrectionPracticeSessionError.noRemainingItems
+        }
+
+        if let next = items.first(where: { !progress.isCompleted(book: bookName, itemId: $0.id) && $0.id != currentBankItemId })
+            ?? items.first(where: { !progress.isCompleted(book: bookName, itemId: $0.id) }) {
+            updatePracticeContext(source: .local(bookName: bookName), item: next, tag: next.tags?.first)
+            return buildState(from: next)
+        }
+
+        throw CorrectionPracticeSessionError.noRemainingItems
+    }
+
+    func savePracticeRecord(response: AIResponse, inputZh: String, inputEn: String, hints: [BankHint]) throws -> PracticeRecord {
+        guard let store = practiceRecordsStore else {
+            throw CorrectionPracticeSessionError.missingPracticeStore
+        }
+
+        let startTime = practiceStartTime ?? Date()
+        let bankBookName: String? = {
+            if case .local(let bookName) = practiceSource { return bookName }
+            return nil
+        }()
+
+        let record = PracticeRecord(
+            createdAt: startTime,
+            completedAt: Date(),
+            bankItemId: currentBankItemId,
+            bankBookName: bankBookName,
+            practiceTag: currentPracticeTag,
+            chineseText: inputZh,
+            englishInput: inputEn,
+            hints: hints,
+            teacherSuggestion: currentSuggestion,
+            correctedText: response.corrected,
+            score: response.score,
+            errors: response.errors
+        )
+
+        store.add(record)
+        AppLog.aiInfo("Practice record saved successfully: score=\(response.score), errors=\(response.errors.count), total records=\(store.records.count)")
+
+        if case .local(let bookName) = practiceSource, let itemId = currentBankItemId, let progress = localProgressStore {
+            if !progress.isCompleted(book: bookName, itemId: itemId) {
+                progress.markCompleted(book: bookName, itemId: itemId, score: response.score)
+            }
+        }
+
+        practiceStartTime = nil
+        return record
+    }
+
+    func resetContext() {
+        practiceSource = nil
+        currentBankItemId = nil
+        currentPracticeTag = nil
+        currentSuggestion = nil
+        practiceStartTime = nil
+    }
+
+    private func updatePracticeContext(source: CorrectionPracticeSource, item: BankItem, tag: String?) {
+        practiceSource = source
+        currentBankItemId = item.id
+        currentPracticeTag = tag
+        currentSuggestion = item.suggestion
+        practiceStartTime = Date()
+    }
+
+    private func buildState(from item: BankItem) -> CorrectionPracticeState {
+        CorrectionPracticeState(
+            inputZh: item.zh,
+            inputEn: "",
+            practicedHints: item.hints,
+            showPracticedHints: false,
+            response: nil,
+            practiceSource: practiceSource,
+            currentBankItemId: currentBankItemId,
+            currentPracticeTag: currentPracticeTag,
+            suggestion: currentSuggestion
+        )
+    }
+}

--- a/ios/translation/Features/Workspace/ViewModels/CorrectionServiceAdapter.swift
+++ b/ios/translation/Features/Workspace/ViewModels/CorrectionServiceAdapter.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+struct CorrectionServiceResult: Equatable {
+    var response: AIResponse
+    var originalHighlights: [Highlight]
+    var correctedHighlights: [Highlight]
+}
+
+protocol CorrectionServiceAdapter {
+    func correct(
+        zh: String,
+        en: String,
+        currentBankItemId: String?,
+        hints: [BankHint],
+        suggestion: String?
+    ) async throws -> CorrectionServiceResult
+}
+
+final class DefaultCorrectionServiceAdapter: CorrectionServiceAdapter {
+    private let service: AIService
+
+    init(service: AIService) {
+        self.service = service
+    }
+
+    func correct(
+        zh: String,
+        en: String,
+        currentBankItemId: String?,
+        hints: [BankHint],
+        suggestion: String?
+    ) async throws -> CorrectionServiceResult {
+        let result: AICorrectionResult
+        if let http = service as? AIServiceHTTP {
+            result = try await http.correct(
+                zh: zh,
+                en: en,
+                bankItemId: currentBankItemId,
+                deviceId: DeviceID.current,
+                hints: hints,
+                suggestion: suggestion
+            )
+        } else {
+            result = try await service.correct(zh: zh, en: en)
+        }
+
+        let response = result.response
+        let originalHighlights = result.originalHighlights
+            ?? Highlighter.computeHighlights(text: en, errors: response.errors)
+        let correctedHighlights = result.correctedHighlights
+            ?? Highlighter.computeHighlightsInCorrected(text: response.corrected, errors: response.errors)
+
+        AppLog.aiInfo("Correction success: score=\(response.score), errors=\(response.errors.count)")
+
+        return CorrectionServiceResult(
+            response: response,
+            originalHighlights: originalHighlights,
+            correctedHighlights: correctedHighlights
+        )
+    }
+}

--- a/ios/translationTests/CorrectionServiceAdapterTests.swift
+++ b/ios/translationTests/CorrectionServiceAdapterTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+@testable import translation
+
+@MainActor
+struct CorrectionServiceAdapterTests {
+    @Test("Adapter computes highlights when backend omits them")
+    func testComputesHighlightsWhenMissing() async throws {
+        let error = ErrorItem(
+            id: UUID(),
+            span: "error",
+            type: .lexical,
+            explainZh: "錯誤",
+            suggestion: "fix",
+            hints: nil
+        )
+        let response = AIResponse(corrected: "This is error", score: 90, errors: [error])
+        let service = MockAIService(result: AICorrectionResult(response: response, originalHighlights: nil, correctedHighlights: nil))
+        let adapter = DefaultCorrectionServiceAdapter(service: service)
+
+        let result = try await adapter.correct(
+            zh: "中文",
+            en: "This is error",
+            currentBankItemId: nil,
+            hints: [],
+            suggestion: nil
+        )
+
+        #expect(result.response == response)
+        #expect(result.originalHighlights.count == 1)
+        #expect(result.correctedHighlights.count == 1)
+        #expect(service.receivedParameters?.zh == "中文")
+    }
+}
+
+private final class MockAIService: AIService {
+    var result: AICorrectionResult
+    var receivedParameters: (zh: String, en: String)? = nil
+
+    init(result: AICorrectionResult) {
+        self.result = result
+    }
+
+    func correct(zh: String, en: String) async throws -> AICorrectionResult {
+        receivedParameters = (zh, en)
+        return result
+    }
+}

--- a/ios/translationTests/CorrectionViewModelTests.swift
+++ b/ios/translationTests/CorrectionViewModelTests.swift
@@ -1,0 +1,183 @@
+import Foundation
+import Testing
+@testable import translation
+
+@MainActor
+struct CorrectionViewModelTests {
+    @Test("runCorrection updates state and posts completion notification")
+    func testRunCorrectionSuccess() async throws {
+        let persistence = MockPersistence()
+        let practiceSession = MockPracticeSession()
+        let serviceAdapter = MockServiceAdapter()
+        let viewModel = CorrectionViewModel(
+            workspaceID: "ws",
+            persistence: persistence,
+            serviceAdapter: serviceAdapter,
+            practiceSession: practiceSession
+        )
+
+        viewModel.inputZh = "中文"
+        viewModel.inputEn = "This is error"
+        let range = viewModel.inputEn.range(of: "error")!
+        let highlight = Highlight(id: UUID(), range: range, type: .lexical)
+        let error = ErrorItem(id: UUID(), span: "error", type: .lexical, explainZh: "說明", suggestion: nil, hints: nil)
+        let response = AIResponse(corrected: "This is error", score: 95, errors: [error])
+        serviceAdapter.result = CorrectionServiceResult(response: response, originalHighlights: [highlight], correctedHighlights: [highlight])
+
+        var posted: [Notification.Name] = []
+        let observer = NotificationCenter.default.addObserver(forName: nil, object: nil, queue: nil) { note in
+            posted.append(note.name)
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        await viewModel.runCorrection()
+
+        #expect(viewModel.response == response)
+        #expect(viewModel.highlights.count == 1)
+        #expect(viewModel.correctedHighlights.count == 1)
+        #expect(viewModel.selectedErrorID == response.errors.first?.id)
+        #expect(posted.contains(.correctionCompleted))
+        #expect(serviceAdapter.received?.zh == "中文")
+    }
+
+    @Test("runCorrection failure posts error notification")
+    func testRunCorrectionFailure() async {
+        let persistence = MockPersistence()
+        let practiceSession = MockPracticeSession()
+        let serviceAdapter = MockServiceAdapter()
+        serviceAdapter.error = NSError(domain: "test", code: 1)
+        let viewModel = CorrectionViewModel(
+            workspaceID: "ws",
+            persistence: persistence,
+            serviceAdapter: serviceAdapter,
+            practiceSession: practiceSession
+        )
+
+        viewModel.inputZh = "中文"
+        viewModel.inputEn = "Hello"
+
+        var posted: [Notification.Name] = []
+        let observer = NotificationCenter.default.addObserver(forName: nil, object: nil, queue: nil) { note in
+            posted.append(note.name)
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        await viewModel.runCorrection()
+
+        #expect(viewModel.errorMessage == serviceAdapter.error?.localizedDescription)
+        #expect(posted.contains(.correctionFailed))
+    }
+
+    @Test("savePracticeRecord delegates to session and posts notification")
+    func testSavePracticeRecord() {
+        let persistence = MockPersistence()
+        let practiceSession = MockPracticeSession()
+        let serviceAdapter = MockServiceAdapter()
+        let viewModel = CorrectionViewModel(
+            workspaceID: "ws",
+            persistence: persistence,
+            serviceAdapter: serviceAdapter,
+            practiceSession: practiceSession
+        )
+
+        let error = ErrorItem(id: UUID(), span: "err", type: .lexical, explainZh: "說明", suggestion: nil, hints: nil)
+        let response = AIResponse(corrected: "Fixed", score: 88, errors: [error])
+        viewModel.response = response
+        viewModel.practicedHints = []
+        practiceSession.saveRecordResult = PracticeRecord(
+            chineseText: "中文",
+            englishInput: "English",
+            hints: [],
+            teacherSuggestion: nil,
+            correctedText: response.corrected,
+            score: response.score,
+            errors: response.errors
+        )
+
+        var posted: [Notification.Name] = []
+        let observer = NotificationCenter.default.addObserver(forName: nil, object: nil, queue: nil) { note in
+            posted.append(note.name)
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        viewModel.savePracticeRecord()
+
+        #expect(practiceSession.savedParameters.count == 1)
+        #expect(posted.contains(.practiceRecordSaved))
+    }
+}
+
+private final class MockPersistence: CorrectionPersistence {
+    var state = CorrectionPersistenceState()
+
+    func load() -> CorrectionPersistenceState { state }
+    func saveInputZh(_ value: String) { state.inputZh = value }
+    func saveInputEn(_ value: String) { state.inputEn = value }
+    func saveResponse(_ response: AIResponse?) { state.response = response }
+    func saveHints(_ hints: [BankHint]) { state.practicedHints = hints }
+    func saveShowPracticedHints(_ value: Bool) { state.showPracticedHints = value }
+    func clearAll() { state = CorrectionPersistenceState() }
+}
+
+private final class MockServiceAdapter: CorrectionServiceAdapter {
+    var result: CorrectionServiceResult?
+    var error: NSError?
+    var received: (zh: String, en: String, hints: [BankHint], suggestion: String?)?
+
+    func correct(zh: String, en: String, currentBankItemId: String?, hints: [BankHint], suggestion: String?) async throws -> CorrectionServiceResult {
+        received = (zh, en, hints, suggestion)
+        if let error { throw error }
+        guard let result else { fatalError("Result not set") }
+        return result
+    }
+}
+
+private final class MockPracticeSession: CorrectionPracticeSession {
+    var practiceSource: CorrectionPracticeSource? = nil
+    var currentBankItemId: String? = nil
+    var currentPracticeTag: String? = nil
+    var currentSuggestion: String? = nil
+
+    var savedParameters: [(response: AIResponse, zh: String, en: String, hints: [BankHint])] = []
+    var saveRecordResult: PracticeRecord?
+
+    func bindLocalStores(localBank: LocalBankStore, progress: LocalBankProgressStore) {}
+    func bindPracticeRecordsStore(_ store: PracticeRecordsStore) {}
+    func startLocalPractice(bookName: String, item: BankItem, tag: String?) -> CorrectionPracticeState {
+        CorrectionPracticeState(
+            inputZh: item.zh,
+            inputEn: "",
+            practicedHints: item.hints,
+            showPracticedHints: false,
+            response: nil,
+            practiceSource: practiceSource,
+            currentBankItemId: currentBankItemId,
+            currentPracticeTag: currentPracticeTag,
+            suggestion: currentSuggestion
+        )
+    }
+    func loadNextPractice() async throws -> CorrectionPracticeState {
+        throw CorrectionPracticeSessionError.noRemainingItems
+    }
+
+    func savePracticeRecord(response: AIResponse, inputZh: String, inputEn: String, hints: [BankHint]) throws -> PracticeRecord {
+        savedParameters.append((response, inputZh, inputEn, hints))
+        if let saveRecordResult { return saveRecordResult }
+        return PracticeRecord(
+            chineseText: inputZh,
+            englishInput: inputEn,
+            hints: hints,
+            teacherSuggestion: currentSuggestion,
+            correctedText: response.corrected,
+            score: response.score,
+            errors: response.errors
+        )
+    }
+
+    func resetContext() {
+        practiceSource = nil
+        currentBankItemId = nil
+        currentPracticeTag = nil
+        currentSuggestion = nil
+    }
+}


### PR DESCRIPTION
## Summary
- extract dedicated persistence, practice session, and AI adapter collaborators for the correction workflow
- update `CorrectionViewModel` and `WorkspaceStore` to assemble the new collaborators while keeping state transitions in the view model
- add unit tests covering the service adapter highlight fallback and view model notification flows

## Testing
- `xcodebuild -project translation.xcodeproj -scheme translation -destination 'platform=iOS Simulator,name=iPhone 16' test` *(fails: xcodebuild not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0dc94e1b88331b02048699ba876a6