### PR TITLE
feat: localize calendar strings

### DIFF
--- a/ios/translation/Features/Calendar/Models/CalendarModels.swift
+++ b/ios/translation/Features/Calendar/Models/CalendarModels.swift
@@ -24,7 +24,9 @@ struct CalendarMonth {
 
     var monthYear: String {
         let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy年M月"
+        formatter.locale = .autoupdatingCurrent
+        formatter.calendar = .autoupdatingCurrent
+        formatter.setLocalizedDateFormatFromTemplate("yyyyMMMM")
         let date = Calendar.current.date(from: DateComponents(year: year, month: month)) ?? Date()
         return formatter.string(from: date)
     }

--- a/ios/translation/Features/Calendar/Views/CalendarView.swift
+++ b/ios/translation/Features/Calendar/Views/CalendarView.swift
@@ -20,13 +20,13 @@ struct CalendarView: View {
             .padding(.horizontal, DS.Spacing.lg)
             .padding(.vertical, DS.Spacing.lg)
         }
-        .navigationTitle("練習日曆")
+        .navigationTitle(Text("calendar.navigation.title"))
         .navigationBarTitleDisplayMode(.large)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 DSQuickActionIconButton(
                     systemName: "calendar.badge.clock",
-                    labelKey: "回到今天",
+                    labelKey: "calendar.action.today",
                     action: viewModel.navigateToToday,
                     style: .tinted
                 )
@@ -56,7 +56,7 @@ struct CalendarView: View {
         HStack(spacing: DS.Spacing.md) {
             DSQuickActionIconButton(
                 systemName: "chevron.left",
-                labelKey: "上個月",
+                labelKey: "calendar.action.previousMonth",
                 action: viewModel.navigateToPreviousMonth,
                 style: .outline
             )
@@ -71,7 +71,7 @@ struct CalendarView: View {
 
             DSQuickActionIconButton(
                 systemName: "chevron.right",
-                labelKey: "下個月",
+                labelKey: "calendar.action.nextMonth",
                 action: viewModel.navigateToNextMonth,
                 style: .outline
             )

--- a/ios/translation/Features/Calendar/Views/DayDetailView.swift
+++ b/ios/translation/Features/Calendar/Views/DayDetailView.swift
@@ -54,17 +54,17 @@ struct DayDetailView: View {
     private var statsGrid: some View {
         HStack(alignment: .center, spacing: DS.Spacing.md) {
             metricColumn(
-                label: "練習題數",
+                label: "calendar.metric.practiceCount",
                 value: "\(stats.count)"
             )
 
             metricColumn(
-                label: "錯誤總數",
+                label: "calendar.metric.totalErrors",
                 value: "\(stats.totalErrors)"
             )
 
             metricColumn(
-                label: "最高分",
+                label: "calendar.metric.bestScore",
                 value: "\(stats.bestScore)"
             )
         }
@@ -100,7 +100,7 @@ struct DayDetailView: View {
                 .dsType(DS.Font.caption)
                 .foregroundStyle(DS.Palette.subdued)
 
-            Text("總練習時間：\(formattedPracticeTime)")
+            Text(verbatim: totalPracticeTimeText)
                 .dsType(DS.Font.caption)
                 .foregroundStyle(DS.Palette.subdued)
         }
@@ -108,25 +108,39 @@ struct DayDetailView: View {
 
     private var formattedMonth: String {
         let formatter = DateFormatter()
-        formatter.dateFormat = "M"
+        formatter.locale = .autoupdatingCurrent
+        formatter.calendar = .autoupdatingCurrent
+        formatter.setLocalizedDateFormatFromTemplate("M")
         return formatter.string(from: stats.date)
     }
 
     private var formattedDay: String {
         let formatter = DateFormatter()
-        formatter.dateFormat = "d"
+        formatter.locale = .autoupdatingCurrent
+        formatter.calendar = .autoupdatingCurrent
+        formatter.setLocalizedDateFormatFromTemplate("d")
         return formatter.string(from: stats.date)
     }
 
     private var formattedPracticeTime: String {
-        let minutes = Int(stats.practiceTime / 60)
-        if minutes < 60 {
-            return "\(minutes) 分鐘"
-        } else {
-            let hours = minutes / 60
-            let remainingMinutes = minutes % 60
-            return "\(hours) 小時 \(remainingMinutes) 分鐘"
+        if stats.practiceTime < 60 {
+            return NSLocalizedString("calendar.practiceTime.lessThanOneMinute", comment: "Practice duration shorter than one minute")
         }
+
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = .short
+        formatter.allowedUnits = stats.practiceTime < 3600 ? [.minute] : [.hour, .minute]
+        formatter.zeroFormattingBehavior = [.dropTrailing]
+        formatter.calendar = .autoupdatingCurrent
+        formatter.locale = .autoupdatingCurrent
+
+        return formatter.string(from: stats.practiceTime)
+            ?? NSLocalizedString("calendar.practiceTime.lessThanOneMinute", comment: "Fallback when practice duration cannot be formatted")
+    }
+
+    private var totalPracticeTimeText: String {
+        let format = NSLocalizedString("calendar.practiceTime.totalFormat", comment: "Label prefix for total practice time with placeholder for formatted duration")
+        return String.localizedStringWithFormat(format, formattedPracticeTime)
     }
 }
 
@@ -213,7 +227,7 @@ private struct AnimatedStreakBadge: View {
             animateGradient = false
         }
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("連續 \(streakDays) 天")
+        .accessibilityLabel(Text("calendar.streak.accessibility \(streakDays)"))
     }
 
     private func gradientCircle(lineWidth: CGFloat) -> some View {

--- a/ios/translation/en.lproj/Localizable.strings
+++ b/ios/translation/en.lproj/Localizable.strings
@@ -17,6 +17,18 @@
 "quick.addWorkspace" = "New Workspace";
 "quick.addEntry" = "Add Entry";
 
+/* Calendar */
+"calendar.navigation.title" = "Practice Calendar";
+"calendar.action.today" = "Today";
+"calendar.action.previousMonth" = "Previous Month";
+"calendar.action.nextMonth" = "Next Month";
+"calendar.metric.practiceCount" = "Practice Items";
+"calendar.metric.totalErrors" = "Total Errors";
+"calendar.metric.bestScore" = "Best Score";
+"calendar.practiceTime.lessThanOneMinute" = "Less than 1 minute";
+"calendar.practiceTime.totalFormat" = "Total practice time: %@";
+"calendar.streak.accessibility" = "Streak %d days";
+
 /* Settings */
 "settings.banner.title" = "Banner";
 "settings.banner.subtitle" = "Set banner display duration";

--- a/ios/translation/zh-Hant.lproj/Localizable.strings
+++ b/ios/translation/zh-Hant.lproj/Localizable.strings
@@ -17,6 +17,18 @@
 "quick.addWorkspace" = "新增工作區";
 "quick.addEntry" = "新增入口";
 
+/* 日曆 */
+"calendar.navigation.title" = "練習日曆";
+"calendar.action.today" = "回到今天";
+"calendar.action.previousMonth" = "上個月";
+"calendar.action.nextMonth" = "下個月";
+"calendar.metric.practiceCount" = "練習題數";
+"calendar.metric.totalErrors" = "錯誤總數";
+"calendar.metric.bestScore" = "最高分";
+"calendar.practiceTime.lessThanOneMinute" = "不到 1 分鐘";
+"calendar.practiceTime.totalFormat" = "總練習時間：%@";
+"calendar.streak.accessibility" = "連續 %d 天";
+
 /* 設定 */
 "settings.banner.title" = "Banner";
 "settings.banner.subtitle" = "設定橫幅顯示秒數";


### PR DESCRIPTION
## Summary
- move the Calendar feature's visible labels into Localizable.strings
- format practice time and streak accessibility strings with localized resources
- generate month titles with locale-aware date formatting

## Testing
- Not run (xcodebuild is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d0ddd58b448331b6324992ba8361b7